### PR TITLE
More efficient fetching single task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "rtm-api",
       "version": "1.3.1",
       "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.7"
+      },
       "devDependencies": {
         "@dwaring87/docdash": "^0.4.1",
         "jsdoc": "^3.6.3"
@@ -219,6 +222,25 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/requizzle": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
@@ -246,6 +268,11 @@
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -257,6 +284,20 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
       "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==",
       "dev": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/xmlcreate": {
       "version": "2.0.4",
@@ -433,6 +474,14 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "requizzle": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
@@ -454,6 +503,11 @@
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -465,6 +519,20 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
       "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==",
       "dev": true
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "xmlcreate": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   },
   "bugs": {
     "url": "https://github.com/dwaring87/rtm-api/issues"
+  },
+  "dependencies": {
+    "node-fetch": "^2.6.7"
   }
 }

--- a/src/user/tasks.js
+++ b/src/user/tasks.js
@@ -149,6 +149,7 @@ module.exports = function(user) {
    * @param {RTMError} callback.err RTM API Error Response, if encountered
    * @param {RTMTask} callback.task Matching RTM Task
    * @function RTMUser~tasks/getTask
+   * @deprecated use rtmIndexFetchTask instead
    */
   rtn.getTask = function(index, filter, callback) {
     if ( callback === undefined && typeof filter === 'function' ) {

--- a/src/user/tasks.js
+++ b/src/user/tasks.js
@@ -4,9 +4,8 @@ const _tasks = require('../task/helper.js');
 const _lists = require('../list/helper.js');
 const taskIds = require('../utils/taskIds.js');
 const errors = require('../response/error.js');
-const sign = require('../utils/sign')
 const { getListId, getTaskId, getTaskSeriesId } = require('../utils/taskIds');
-const { callAPI, formQuery, buildUrl } = require('../utils/fetch')
+const { callAPI, buildUrl } = require('../utils/fetch')
 const RTMTask = require('../task/index.js');
 
 /**

--- a/src/user/tasks.js
+++ b/src/user/tasks.js
@@ -117,31 +117,26 @@ module.exports = function(user) {
     let listId = getListId(user.id,index)
     let taskSeriesId = getTaskSeriesId(user.id,index)
     let taskId = getTaskId(user.id,index)
-    // console.log({listId,taskSeriesId,taskId})
-    // TODO if undefined return error
+
     if (listId == undefined || taskSeriesId == undefined || taskId == undefined) {
       return {err: {code: -3}} // Not sure why this is the code
     }
-        // filter the response for the index
-    // TODO refactor this, maybe return RTMTask
+    // filter the response for the matching index
     let taskList = lists.filter(x => x.id == listId)[0].taskseries
     let taskSeries = taskList ? taskList.filter(x => x.id == taskSeriesId)[0] : null
-    // console.log(taskSeries)
-    // ONly return the single task from the series.  This is usually turned into an RTM task
     taskSeries
       ? taskSeries.task = taskSeries.task.filter(x => x.id == taskId)[0]
       : null
 
-    // console.log(taskSeries.task)
-    // console.log({user:user.id,listId,taskSeries,task:taskSeries.task})
+
     let err
-    let returnTask
+    let task
     if (!taskSeries ) {
       err = {code: -3} // Not sure why this is the code 
     }  else {
-      returnTask = new RTMTask(user.id,listId,taskSeries,taskSeries.task)
+      task = new RTMTask(user.id,listId,taskSeries,taskSeries.task)
     }
-    return {err,task:returnTask}
+    return {err,task}
   }
 
   /**

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -1,0 +1,67 @@
+const fetch = require('node-fetch');
+const sign = require('../utils/sign')
+
+
+// API Configuration Properties
+const config = require('../../config');
+const scheme = config.api.scheme;
+const base = config.api.url.base;
+const format = config.api.format;
+const version = config.api.version;
+
+
+function buildUrl(user,filter) {
+  let query = {
+    filter: filter ,
+    auth_token: user._authToken,
+    method: 'rtm.tasks.getList',
+    api_key: user._client._apiKey,
+    v: version,
+    format
+  }
+
+  let apiSig=sign(query,{secret:user._client._apiSecret})
+
+  let url = `${scheme}://${base}?${formQuery(query)}&api_sig=${apiSig}`
+  return url
+}
+
+
+
+
+/**
+ * Generate a URI Encoded query string from the parameters set of
+ * key/value pairs
+ * @param {object} params Object containing the key/value parameters
+ * @returns {string} URL Encoded query string
+ */
+function formQuery(params) {
+let parts = [];
+for ( let key in params ) {
+    if ( params.hasOwnProperty(key) ) {
+    parts.push(encodeURIComponent(key) + "=" + encodeURIComponent(params[key]));
+    }
+}
+return parts.join("&");
+}
+
+/**
+ * 
+ * @param {string} url fully formed url to call
+ * @returns JSON response
+ */
+async function callAPI(url) {
+  try {
+      const response = await fetch(url);
+      if (await response.ok) {
+          return await response.json();
+      } else {
+          // TODO improve this error message
+          console.error('There was an error');
+      }
+    } catch (error) {
+        console.error(error)
+    }
+}
+
+module.exports = {callAPI,formQuery, buildUrl}


### PR DESCRIPTION
Adds a new method to get a single task `users.tast.rtmIndexFetchTask()` to replace `users.tasks.getTask()`. This new method is promise based, uses `node-fetch` and is more performant in that it does not create an `RTMTask` for every task that is returned by a filter, just the one that matches the index.

This performance issue has been causing me some problems as I've used Remember the Milk for many years and have a large number of tasks with URLs or notes and to find these tasks, even when using the index, the client has to make a very wide open `hasUrl:true` filter and then pare it down to the task that matches the index.

The existing `getTask()` has been marked deprecated, but no features have been removed.

This is the first commit in my fork to modernize and maintain the rtm-api