### PR TITLE
feat: includes recurrence rule on RTMTask object

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "main": "src/client/index.js",
   "scripts": {
     "docs": "jsdoc -c jsdoc.json --readme README.md --template node_modules/@dwaring87/docdash",
-    "test": "jest --passWithNoTests",
+    "test": "jest",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "release": "standard-version",

--- a/src/task/index.js
+++ b/src/task/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const taskIds = require('../utils/taskIds.js');
+const rruleToISODuration = require('../utils/rruleToDuration.js');
 
 
 /**
@@ -210,6 +211,15 @@ class RTMTask {
      * @type {boolean}
      */
     this.isRecurring = series.rrule ? true : false;
+
+    /**
+     * Task recurrence rule
+     * @type {string}}
+     */
+    this.recurrenceRule = series.rrule?.toString() === '' ? undefined : rruleToISODuration(series.rrule);
+    this.recurrenceRuleRaw = series.rrule?.toString() === '' ? undefined : JSON.stringify(series.rrule);
+
+
 
     /**
      * Task subtask flag

--- a/src/utils/rruleToDuration.js
+++ b/src/utils/rruleToDuration.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * Convert an RTM-style rrule object into an ISO 8601 duration string.
+ * @param {{ $t: string }} rrule - Object with $t property like 'FREQ=DAILY;INTERVAL=1;WKST=SU'
+ * @returns {string} ISO 8601 duration string (e.g. 'P1D', 'PT3H')
+ * @throws {Error} on missing or unsupported frequency
+ */
+function rruleToISODuration(rrule) {
+  if (!rrule || typeof rrule.$t !== 'string') {
+    throw new Error('Invalid rrule object');
+  }
+
+  const parts = rrule.$t
+    .split(';')
+    .map(p => p.split('='))
+    .reduce((acc, [k, v]) => {
+      acc[k] = v;
+      return acc;
+    }, {});
+
+  const freq = parts.FREQ;
+  const interval = parseInt(parts.INTERVAL || '1', 10);
+  const freqMap = {
+    YEARLY: 'Y',
+    MONTHLY: 'M',
+    WEEKLY: 'W',
+    DAILY: 'D',
+    HOURLY: 'H',
+    MINUTELY: 'M',
+    SECONDLY: 'S',
+  };
+
+  const designator = freqMap[freq];
+  if (!designator) {
+    throw new Error(`Unsupported FREQ: ${freq}`);
+  }
+
+  const timeBased = ['HOURLY', 'MINUTELY', 'SECONDLY'].includes(freq);
+  return `${timeBased ? 'PT' : 'P'}${interval}${designator}`;
+}
+
+module.exports = rruleToISODuration;

--- a/src/utils/rruleToDuration.test.js
+++ b/src/utils/rruleToDuration.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const rruleToISODuration = require('./rruleToDuration');
+
+describe('rruleToISODuration', () => {
+  test('daily with explicit interval', () => {
+    const rrule = { $t: 'FREQ=DAILY;INTERVAL=1;WKST=SU' };
+    expect(rruleToISODuration(rrule)).toBe('P1D');
+  });
+
+  test('weekly without interval (defaults to 1)', () => {
+    const rrule = { $t: 'FREQ=WEEKLY;WKST=SU' };
+    expect(rruleToISODuration(rrule)).toBe('P1W');
+  });
+
+  test('monthly with interval 2', () => {
+    const rrule = { $t: 'FREQ=MONTHLY;INTERVAL=2' };
+    expect(rruleToISODuration(rrule)).toBe('P2M');
+  });
+
+  test('hourly with interval 3', () => {
+    const rrule = { $t: 'FREQ=HOURLY;INTERVAL=3' };
+    expect(rruleToISODuration(rrule)).toBe('PT3H');
+  });
+
+  test('minutely with interval 15', () => {
+    const rrule = { $t: 'FREQ=MINUTELY;INTERVAL=15' };
+    expect(rruleToISODuration(rrule)).toBe('PT15M');
+  });
+
+  test('secondly with interval 30', () => {
+    const rrule = { $t: 'FREQ=SECONDLY;INTERVAL=30' };
+    expect(rruleToISODuration(rrule)).toBe('PT30S');
+  });
+
+  test('unsupported frequency throws', () => {
+    const rrule = { $t: 'FREQ=UNKNOWN;INTERVAL=1' };
+    expect(() => rruleToISODuration(rrule)).toThrow('Unsupported FREQ: UNKNOWN');
+  });
+
+  test('invalid object throws', () => {
+    expect(() => rruleToISODuration(null)).toThrow('Invalid rrule object');
+    expect(() => rruleToISODuration({})).toThrow('Invalid rrule object');
+  });
+});


### PR DESCRIPTION
Includes the recurrence rule both as an ISO-8601 duration and in its raw form on the RTMTask object

`recurrenceRule` and `recurrenceRuleRaw`

- Adds a function to convert from the RTM recurrence format to a duration
- Adds unit tests for the conversion function

Resolves #66
